### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-geowizard"
+description = ""
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["diffusers >= 0.26.0", "numpy >= 1.23.1", "Pillow", "matplotlib>=3.7.5", "scikit-image>=0.18.1", "tqdm >= 4.65.0", "accelerate>=0.28.0", "transformers>=4.39.1"]
+
+[project.urls]
+Repository = "https://github.com/kijai/ComfyUI-Geowizard"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-Geowizard"
+Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-geowizard"
-description = ""
+description = "This is a diffusers (0.27.2) wrapper node for Geowizard: [https://github.com/fuxiao0719/GeoWizard]. The model is autodownloaded from Hugginface to ComfyUI/models/diffusers/geowizard"
 version = "1.0.0"
 license = "LICENSE"
 dependencies = ["diffusers >= 0.26.0", "numpy >= 1.23.1", "Pillow", "matplotlib>=3.7.5", "scikit-image>=0.18.1", "tqdm >= 4.65.0", "accelerate>=0.28.0", "transformers>=4.39.1"]


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!